### PR TITLE
Use REPLACE on db row creation for initial reorg logic

### DIFF
--- a/storage/sqlite3.go
+++ b/storage/sqlite3.go
@@ -123,6 +123,7 @@ func GetBlockRange(ctx context.Context, db *sql.DB, blockOut chan<- []byte, errO
 
 func StoreBlock(conn *sql.DB, height int, hash string, sapling bool, encoded []byte) error {
 	insertBlock := "REPLACE INTO blocks (block_height, block_hash, sapling, compact_encoding) values (?, ?, ?, ?)"
+
 	tx, err := conn.Begin()
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("creating db tx %d", height))

--- a/storage/sqlite3.go
+++ b/storage/sqlite3.go
@@ -122,8 +122,7 @@ func GetBlockRange(ctx context.Context, db *sql.DB, blockOut chan<- []byte, errO
 }
 
 func StoreBlock(conn *sql.DB, height int, hash string, sapling bool, encoded []byte) error {
-	insertBlock := "INSERT INTO blocks (block_height, block_hash, sapling, compact_encoding) values (?, ?, ?, ?)"
-
+	insertBlock := "REPLACE INTO blocks (block_height, block_hash, sapling, compact_encoding) values (?, ?, ?, ?)"
 	tx, err := conn.Begin()
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("creating db tx %d", height))


### PR DESCRIPTION
This PR is a naive solution(intended to partially address #32, #35  short term) to the existing reorgs issue that causes lightwalletd to abruptly/randomly stop.

`INSERT` cannot handle reorg block row creation, due to UNIQUE constraints on the row data.

`REPLACE` will remove and replace the row entry causing the unique constraint. 

My initial thoughts were lightwalletd can replace duplicate(containing same height and or hash) blocks, and assume the last received duplicate block will contain the chain-valid block. 

I need to go test this more, but thoughts/ideas are welcome.

(Disclaimer; I'm a Golang newb and just started with this portion of the stack a few days ago 😄 ) 