### PR TITLE
Remove go routine that causes threading issues when writing to local db

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -157,8 +157,7 @@ func main() {
 		switch string(topic) {
 
 		case opts.zmqTopic:
-			// there's an implicit mutex here
-			go handleBlock(db, sequence, body)
+			handleBlock(db, sequence, body)
 
 		default:
 			log.WithFields(logrus.Fields{


### PR DESCRIPTION
Str4d and I noticed, in a pairing, that threading issues writing to the DB are likely rooted in the `go` routine.