### PR TITLE
suggest pre-commit code formatting hook, format existing code

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,34 @@ lightwalletd currently lacks several things that you'll want in production. Cave
 - Logging may capture identifiable user data. It hasn't received any privacy analysis yet and makes no attempt at sanitization.
 - The only storage provider we've implemented is sqlite. sqlite is [likely not appropriate](https://sqlite.org/whentouse.html) for the number of concurrent requests we expect to handle. Because sqlite uses a global write lock, the code limits the number of open database connections to *one* and currently makes no distinction betwen read-only (frontend) and read/write (ingester) connections. It will probably begin to exhibit lock contention at low user counts, and should be improved or replaced with your own data store in production.
 - [Load-balancing with gRPC](https://grpc.io/blog/loadbalancing) may not work quite like you're used to. A full explanation is beyond the scope of this document, but we recommend looking into [Envoy](https://www.envoyproxy.io/), [nginx](https://nginx.com), or [haproxy](https://www.haproxy.org) depending on your existing infrastruture.
+
+**Pull Requests**
+
+We welcome pull requests! We like to keep our Go code neatly formatted in a standard way,
+which the standard tool [gofmt](https://golang.org/cmd/gofmt/) can do. Please consider
+adding the following to the file `.git/hooks/pre-commit` in your clone:
+
+```
+#!/bin/sh
+
+modified_go_files=$(git diff --cached --name-only -- '*.go')
+if test "$modified_go_files"
+then
+    need_formatting=$(gofmt -l $modified_go_files)
+    if test "$need_formatting"
+    then
+        echo files need formatting:
+        echo gofmt -w $need_formatting
+        exit 1
+    fi
+fi
+```
+
+You'll also need to make this file executable:
+
+```
+$ chmod +x .git/hooks/pre-commit
+```
+
+Doing this will prevent commits that break the standard formatting. Simply run the
+`gofmt` command as indicated and rerun the `git commit` command.

--- a/parser/block.go
+++ b/parser/block.go
@@ -86,10 +86,10 @@ func (b *block) GetHeight() int {
 func (b *block) ToCompact() *walletrpc.CompactBlock {
 	compactBlock := &walletrpc.CompactBlock{
 		//TODO ProtoVersion: 1,
-		Height: uint64(b.GetHeight()),
-		Hash:   b.GetEncodableHash(),
+		Height:   uint64(b.GetHeight()),
+		Hash:     b.GetEncodableHash(),
 		PrevHash: b.hdr.HashPrevBlock,
-		Time:   b.hdr.Time,
+		Time:     b.hdr.Time,
 	}
 
 	// Only Sapling transactions have a meaningful compact encoding

--- a/vendor/github.com/btcsuite/btcutil/certgen.go
+++ b/vendor/github.com/btcsuite/btcutil/certgen.go
@@ -110,7 +110,7 @@ func NewTLSCertPair(organization string, validUntil time.Time, extraHosts []stri
 
 		KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature |
 			x509.KeyUsageCertSign,
-		IsCA: true, // so can sign self.
+		IsCA:                  true, // so can sign self.
 		BasicConstraintsValid: true,
 
 		DNSNames:    dnsNames,

--- a/vendor/gopkg.in/ini.v1/key.go
+++ b/vendor/gopkg.in/ini.v1/key.go
@@ -186,8 +186,8 @@ func (k *Key) Float64() (float64, error) {
 
 // Int returns int type value.
 func (k *Key) Int() (int, error) {
-    v, err := strconv.ParseInt(k.String(), 0, 64)
-    return int(v), err
+	v, err := strconv.ParseInt(k.String(), 0, 64)
+	return int(v), err
 }
 
 // Int64 returns int64 type value.
@@ -669,7 +669,7 @@ func (k *Key) parseInts(strs []string, addInvalid, returnOnInvalid bool) ([]int,
 	vals := make([]int, 0, len(strs))
 	for _, str := range strs {
 		valInt64, err := strconv.ParseInt(str, 0, 64)
-		val := int(valInt64)        
+		val := int(valInt64)
 		if err != nil && returnOnInvalid {
 			return nil, err
 		}


### PR DESCRIPTION
One of the great features of Golang is its formatting tool: https://blog.golang.org/go-fmt-your-code. This PR adds a description to `README.md` to help developers set up a pre-commit hook, something that runs on every `git commit`, that rejects the commit if the Go files are not formatted. There's no way to commit this hook so that people have it automatically; each developer must set it up.

We could add further hooks in the future, such as `golint`, but those require people to install stuff. Why don't we start small and see how it goes. 

This commit includes actually running `gofmt` on the entire repo (as you can see, only a few things were off).