### PR TITLE
Security and usability fixes to CLI and repo with .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.conf
+*.config
+*.log
+*.sqlite
+*.pem
+*.key


### PR DESCRIPTION
Added .gitignore, provided command line defaults, made errors more obvious, told users to check the log file after it is initialized when a fatal error occurs, require users to pass -very-insecure=true when not using TLS certificates