### PR TITLE
update makefile targets and gitlab-ci.yml for unittest patch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
   - monitor
 
 before_script:
-  - apk update && apk add make git gcc musl-dev sqlite
+  - apk update && apk add make git gcc musl-dev
 
 # ************************************************************************/
 # BUILD
@@ -78,6 +78,7 @@ test-coverage:
     - make coverage
     - make coverage_report
     - make coverage_html
+  allow_failure: true
   artifacts:
     paths:
     - ./coverage.html

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,9 +38,6 @@ build-linux:
   stage: build
   script:
     - make
-  only:
-    - merge_requests
-    - master
 
 .build-windows:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ build-linux:
     - make
 
 # Build against latest Golang
-build-latest:
+.build-latest:
   stage: build
   image: golang:latest-alpine
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,6 @@ stages:
 
 before_script:
   - apk update && apk add make git gcc musl-dev
-  - export GO111MODULE=on
-  - export CGO_ENABLED=1
 
 # ************************************************************************/
 # BUILD
@@ -55,40 +53,37 @@ build-linux:
     - make
 
 # Build against latest Golang
-.build-latest:
+build-latest:
   stage: build
   image: golang:latest-alpine
   script:
     - make
   allow_failure: true 
 
-# Likely don't need a nightly in always deployable model; will revisit after requirement gathering
-.build-nightly:
-  stage: build
-  script:
-    - make
-  allow_failure: true
-
 # ************************************************************************/
 # TEST
 # ************************************************************************/
+test-unittest:
+  stage: test
+  script:
+    - make test
+  allow_failure: true
+
+test-race-conditions:
+  stage: test
+  script:
+    - make race
+  allow_failure: true
+
 test-coverage:
   stage: test
   script:
     - make coverage
-  allow_failure: true  
-
-test-coverage-report:
-  stage: test
-  script:
     - make coverage_report
-  allow_failure: true
-
-test-coverage-report-html:
-  stage: test
-  script:
     - make coverage_html
-  allow_failure: true
+  artifacts:
+    paths:
+    - ./coverage.html
 
 # ************************************************************************/
 # DEPLOY

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
   - monitor
 
 before_script:
-  - apk update && apk add make git gcc musl-dev
+  - apk update && apk add make git gcc musl-dev sqlite3
 
 # ************************************************************************/
 # BUILD

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
   - monitor
 
 before_script:
-  - apk update && apk add make git gcc musl-dev sqlite3
+  - apk update && apk add make git gcc musl-dev sqlite
 
 # ************************************************************************/
 # BUILD

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,13 @@
  #  Usage: make <target_name>
  #
  #  Known bugs/missing features:
+ #  1. make msan is not stable as of 9/20/2019
  #
  # ************************************************************************/
 PROJECT_NAME := "lightwalletd"
 GO_FILES := $(shell find . -name '*.go' | grep -v /vendor/ | grep -v '*_test.go')
 GO_TEST_FILES := $(shell find . -name '*_test.go' -type f | rev | cut -d "/" -f2- | rev | sort -u)
 GO_BUILD_FILES := $(shell find . -name 'main.go')
-
-#PKG_LIST := $(shell go list | grep -v /vendor/)
-#GO_COV_REPORTS :=
 
 .PHONY: all dep build clean test coverage coverhtml lint
 
@@ -29,19 +27,19 @@ show_tests:
 
 # Run unittests
 test:
-	@go test -v -short ${GO_TEST_FILES}
+	@go test -v ./...
 
 # Run data race detector
-race: dep
-	@go test -v -race -short ${GO_TEST_FILES}
+race:
+	@go test -v -race -short ./...
 
 # Run memory sanitizer (need to ensure proper build flag is set)
-msan: dep
+msan:
 	@go test -v -msan -short ${GO_TEST_FILES}
 
 # Generate global code coverage report
 coverage:
-	@go test -coverprofile=coverage.out ${GO_TEST_FILES}
+	@go test -coverprofile=coverage.out ./...
 
 # Generate code coverage report
 coverage_report:
@@ -49,7 +47,7 @@ coverage_report:
 
 # Generate code coverage report in HTML
 coverage_html: 
-	@go tool cover -html=coverage.out
+	@go tool cover -html=coverage.out -o coverage.html
 
 # Generate documents
 docs:
@@ -65,8 +63,8 @@ dep:
 
 # Build binary
 build:
-	@go build -i -v ./cmd/ingest
-	@go build -i -v ./cmd/server
+	GO111MODULE=on CGO_ENABLED=1 go build -i -v ./cmd/ingest
+	GO111MODULE=on CGO_ENABLED=1 go build -i -v ./cmd/server
 
 # Install binaries into Go path
 install:


### PR DESCRIPTION
In order to support golang formalities, I updated the targets to be consistent with `./...`

Also updating the coverage generation to host the coverage.html

Removing the fluff that does not do anything to support fork PRs.

Added gitlab job to build against golang latest so we have upstream reference of things that could break.

