### PR TITLE
Zecwallet Lightclient service changes

### DIFF
--- a/walletrpc/service.proto
+++ b/walletrpc/service.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package cash.z.wallet.sdk.rpc;
 option go_package = "walletrpc";
-option swift_prefix = "";
+
 import "compact_formats.proto";
 
 // A BlockID message contains identifiers to select a block: a height or a
@@ -27,9 +27,11 @@ message TxFilter {
      bytes hash = 3;
 }
 
-// RawTransaction contains the complete transaction data.
+// RawTransaction contains the complete transaction data. It also optionally includes 
+// the block height in which the transaction was included
 message RawTransaction {
     bytes data = 1;
+    uint64 height = 2;
 }
 
 message SendResponse {
@@ -40,10 +42,40 @@ message SendResponse {
 // Empty placeholder. Someday we may want to specify e.g. a particular chain fork.
 message ChainSpec {}
 
+message Empty {}
+
+message LightdInfo {
+    string version = 1;
+    string vendor = 2;
+    bool   taddrSupport = 3;
+    string chainName = 4;
+    uint64 saplingActivationHeight = 5;
+    string consensusBranchId = 6;   // This should really be u32 or []byte, but string for readability
+    uint64 blockHeight = 7;
+}
+
+message TransparentAddress {
+    string address = 1;
+}
+
+message TransparentAddressBlockFilter {
+    string address = 1;
+    BlockRange range = 2;
+}
+
 service CompactTxStreamer {
+    // Compact Blocks
     rpc GetLatestBlock(ChainSpec) returns (BlockID) {}
     rpc GetBlock(BlockID) returns (CompactBlock) {}
     rpc GetBlockRange(BlockRange) returns (stream CompactBlock) {}
+
+    // Transactions
     rpc GetTransaction(TxFilter) returns (RawTransaction) {}
     rpc SendTransaction(RawTransaction) returns (SendResponse) {}
+
+    // t-Address support
+    rpc GetAddressTxids(TransparentAddressBlockFilter) returns (stream RawTransaction) {}
+
+    // Misc
+    rpc GetLightdInfo(Empty) returns (LightdInfo) {}
 }


### PR DESCRIPTION
This PR is just FYI to show the final RPC changes that Zecwallet lightclient has implemented.

This adds:
- T address support
- Info to get additional details from the server for creating + sending transactions