### PR TITLE
remove ingestor artifact upload

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ before_script:
 .build-docs:
   stage: build
   script:
-    - made docs
+    - make docs
 
 build:build-linux:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,6 @@ build:build-linux:
   artifacts:
     paths:
     - ./server
-    - ./ingest
 
 .build-windows:
   stage: build


### PR DESCRIPTION
Remove the ingestor binary upload step in gitlab for upcoming PRs that completely remove ingester source.