### PR TITLE
Auto generate certs for local development

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -105,12 +105,11 @@ func fileExists(filename string) bool {
 func main() {
 	opts := &Options{}
 	flag.StringVar(&opts.bindAddr, "bind-addr", "127.0.0.1:9067", "the address to listen on")
-	flag.StringVar(&opts.tlsCertPath, "tls-cert", "./cert.pem", "the path to a TLS certificate")
-	flag.StringVar(&opts.tlsKeyPath, "tls-key", "./cert.key", "the path to a TLS key file")
+	flag.StringVar(&opts.tlsCertPath, "tls-cert", "", "the path to a TLS certificate")
+	flag.StringVar(&opts.tlsKeyPath, "tls-key", "", "the path to a TLS key file")
 	flag.Uint64Var(&opts.logLevel, "log-level", uint64(logrus.InfoLevel), "log level (logrus 1-7)")
 	flag.StringVar(&opts.logPath, "log-file", "./server.log", "log file to write to")
 	flag.StringVar(&opts.zcashConfPath, "conf-file", "./zcash.conf", "conf file to pull RPC creds from")
-	flag.BoolVar(&opts.veryInsecure, "no-tls-very-insecure", false, "run without the required TLS certificate, only for debugging, DO NOT use in production")
 	flag.BoolVar(&opts.wantVersion, "version", false, "version (major.minor.patch)")
 	flag.IntVar(&opts.cacheSize, "cache-size", 80000, "number of blocks to hold in the cache")
 
@@ -124,19 +123,16 @@ func main() {
 	}
 
 	filesThatShouldExist := []string{
-		opts.tlsCertPath,
-		opts.tlsKeyPath,
-		opts.logPath,
 		opts.zcashConfPath,
+	}
+	if opts.tlsCertPath != "" {
+		filesThatShouldExist = append(filesThatShouldExist, opts.tlsCertPath)
+	}
+	if opts.tlsKeyPath != "" {
+		filesThatShouldExist = append(filesThatShouldExist, opts.tlsKeyPath)
 	}
 
 	for _, filename := range filesThatShouldExist {
-		if !fileExists(opts.logPath) {
-			os.OpenFile(opts.logPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
-		}
-		if opts.veryInsecure && (filename == opts.tlsCertPath || filename == opts.tlsKeyPath) {
-			continue
-		}
 		if !fileExists(filename) {
 			os.Stderr.WriteString(fmt.Sprintf("\n  ** File does not exist: %s\n\n", filename))
 			flag.Usage()
@@ -162,11 +158,15 @@ func main() {
 
 	// gRPC initialization
 	var server *grpc.Server
+	var transportCreds credentials.TransportCredentials
+	var err error
 
-	if opts.veryInsecure {
-		server = grpc.NewServer(LoggingInterceptor())
+	if (opts.tlsCertPath == "") && (opts.tlsKeyPath == "") {
+		log.Warning("Certificate and key not provided, generating self signed values")
+		tlsCert := common.GenerateCerts()
+		transportCreds = credentials.NewServerTLSFromCert(tlsCert)
 	} else {
-		transportCreds, err := credentials.NewServerTLSFromFile(opts.tlsCertPath, opts.tlsKeyPath)
+		transportCreds, err = credentials.NewServerTLSFromFile(opts.tlsCertPath, opts.tlsKeyPath)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"cert_file": opts.tlsCertPath,
@@ -174,8 +174,8 @@ func main() {
 				"error":     err,
 			}).Fatal("couldn't load TLS credentials")
 		}
-		server = grpc.NewServer(grpc.Creds(transportCreds), LoggingInterceptor())
 	}
+	server = grpc.NewServer(grpc.Creds(transportCreds), LoggingInterceptor())
 
 	// Enable reflection for debugging
 	if opts.logLevel >= uint64(logrus.WarnLevel) {

--- a/common/generatecerts.go
+++ b/common/generatecerts.go
@@ -1,0 +1,72 @@
+package common
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"math/big"
+	"time"
+)
+
+// GenerateCerts create self signed certificate for local development use
+func GenerateCerts() (cert *tls.Certificate) {
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	publicKey := &privKey.PublicKey
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		log.Fatalf("Failed to generate serial number: %s", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Lighwalletd developer"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Local().Add(time.Hour * 24 * 365),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	// List of hostnames and IPs for the cert
+	template.DNSNames = append(template.DNSNames, "localhost")
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey, privKey)
+	if err != nil {
+		log.Fatalf("Failed to create certificate: %s", err)
+	}
+
+	// PEM encode the certificate (this is a standard TLS encoding)
+	b := pem.Block{Type: "CERTIFICATE", Bytes: certDER}
+	certPEM := pem.EncodeToMemory(&b)
+	fmt.Printf("%s\n", certPEM)
+
+	// PEM encode the private key
+	privBytes, err := x509.MarshalPKCS8PrivateKey(privKey)
+	if err != nil {
+		log.Fatalf("Unable to marshal private key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: privBytes,
+	})
+
+	// Create a TLS cert using the private key and certificate
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		log.Fatalf("invalid key pair: %v", err)
+	}
+
+	cert = &tlsCert
+	return cert
+
+}


### PR DESCRIPTION
This PR will remove the defaults for the TLS cert and key.

If no values are provided
- a warning log message will indicate no TLS setting are provided
- a self signed cert will be generated, and outputted (for reference only, the key is only held in memory)
- the cert will be different on server restarts

Advantages provided:
- removes the need to switch back and forth between plain-text and TLS when using GRPC
- removes the need of scripting for development environments or providing instructions for certificate generation

Example usage:
```
$ make && ./server -log-file /dev/stdout
GO111MODULE=on CGO_ENABLED=1 go build -i -v ./cmd/server
{"app":"frontend-grpc","level":"warning","msg":"Certificate and key not provided, generating self signed values","time":"202
0-01-02T10:07:11-05:00"}
-----BEGIN CERTIFICATE-----
MIIDFTCCAf2gAwIBAgIQUPtA5DsTelAzN9kbUgX0JzANBgkqhkiG9w0BAQsFADAg
MR4wHAYDVQQKExVMaWdod2FsbGV0ZCBkZXZlbG9wZXIwHhcNMjAwMTAyMTUwNzEx
WhcNMjEwMTAxMTUwNzExWjAgMR4wHAYDVQQKExVMaWdod2FsbGV0ZCBkZXZlbG9w
ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4APkzmCez26HLvFi4
+BkCv+1ktP0znMN28jKRjFA3CLSubO80mASLdiEoTvyuucL0QpX49ElOk0OajM4H
MU7nihpFnjwHxyKjp7FPJTRkA+2Ad2CItDmIwHJu0fsrcMT1sYo2hE6DarX3GlpR
gQL3Bd2NvVwpW/929ElST6YAzBUN9H8eLyBa5AImGMWK8h2NQF1GSmc7kIFvUM2n
O4IJuvr8OpYGGq2Mr8VDZwzak7duzapm98h1yW1aL0+Eqqk2Vb3Ek5qZ57EsGgiB
aJayiJRaRKljZ7RihVtTP+mVB0SLNwUe3gU6mnesFBAeCwAMP3yuVinDrenbG1d7
eG4pAgMBAAGjSzBJMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcD
ATAMBgNVHRMBAf8EAjAAMBQGA1UdEQQNMAuCCWxvY2FsaG9zdDANBgkqhkiG9w0B
AQsFAAOCAQEAbyR7sI4Yv+JstCsUypbuW7UW8uRK7bYvt0yUEu+7MqYHiBU0ovlH
ddVI7M9XgjxKc6l6yAKcNVicCB7MSdCapRMnNs2URypXFs/diAHTYiSlnVSGorxX
2AACORH+qeMNDE40/2WVeKvqo+lcj6AB6kV7CVuPmrFZH6Xff4VhGe+strxxCnaH
42JRNxpjVr2HguJWoUwihBU2CI8DKw4PbiCaYL+6N6SLXjJOLGg8qI17chMMEt89
p7hRcsUXINbFNVLvQut6ydx/7Ng0kRYffkdF3tqk1+rz5LNlDWwqTIVBhuYFFJO7
fwQHHkLQwTNFZtBTNeiHCWVVo4opr2qOKA==
-----END CERTIFICATE-----

{"app":"frontend-grpc","error":"Post http:: http: no Host in request URL","level":"warning","msg":"error with getblockchaini
nfo rpc, retrying...","retry":1,"time":"2020-01-02T10:07:11-05:00"}
```